### PR TITLE
Cross build for Scala 2.10 and 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ version := "0.2.5-SNAPSHOT"
 
 isSnapshot := true
 
-scalaVersion := "2.10.3"
+crossScalaVersions := Seq("2.10.3", "2.11.1")
 
 resolvers += "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository"
 


### PR DESCRIPTION
I think this is the right way to do it...
If you could release a 2.11-compatible version, that would be great! :-)
